### PR TITLE
SCRUM-35 add SceletonGrid component and integrate into multiple pages for load…

### DIFF
--- a/frontend/src/common/components/ui/sceleton/SceletonGrid.jsx
+++ b/frontend/src/common/components/ui/sceleton/SceletonGrid.jsx
@@ -1,0 +1,19 @@
+import s from './SceletonGrid.module.css';
+
+export default function SceletonGrid({
+  count = 12,
+  itemHeight = 422,      
+  borderRadius = 12,
+
+}) {
+  const itemStyle = { height: `${itemHeight}px`, borderRadius: `${borderRadius}px` };
+  const indices = [...Array(count).keys()]; // [0,1,2,...,count-1]
+
+  return (
+    <div className={s.grid}>
+      {indices.map((i) => (
+        <div key={i} className={s.item} style={itemStyle} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/common/components/ui/sceleton/SceletonGrid.module.css
+++ b/frontend/src/common/components/ui/sceleton/SceletonGrid.module.css
@@ -1,0 +1,11 @@
+.grid {
+    display: contents;
+}
+
+.item {
+    aspect-ratio: 316 / 422;
+    width: 100%;
+    background: #F2F6D3;
+    position: relative;
+    overflow: hidden;
+}

--- a/frontend/src/features/categories/pages/CategoriesPage.jsx
+++ b/frontend/src/features/categories/pages/CategoriesPage.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchCategories } from '@redux/slices/categorySlice.js';
 import CategoriesItems from "@features/home/components/CategoriesItems.jsx";
-
+import SceletonGrid from '@common/components/ui/sceleton/SceletonGrid.jsx';
 import TitleList from '@common/components/ui/title/TitleList.jsx';
 import { Loader } from '@common/components';
 
@@ -11,6 +11,7 @@ import styles from './CategoriesPage.module.css'
 const CategoriesPage = () => {
   const dispatch = useDispatch();
   const { items, status, error } = useSelector((state) => state.categories || { items: [], status: 'idle', error: null });
+  const isFirstLoad = status === 'loading' && items.length === 0;
 
   useEffect(() => {
     console.log('Dispatching fetchCategories...');
@@ -32,15 +33,19 @@ const CategoriesPage = () => {
     { id: 5, title: "Accessories", image: "/category_img/5.jpeg" },
   ];
 
-  const categoriesToShow = items.length > 0 ? getRandomCategories(items, 5) : fallbackCategories;
+  const categoriesToShow = isFirstLoad
+    ? []
+    : (items.length > 0 ? getRandomCategories(items, 5) : fallbackCategories);
 
   return (
     <div className={styles.categoriesPage}>
       <TitleList title="Categories" />
       <div className={styles.categoriesGrid}>
-        {status === 'loading' && <Loader />}
+        {isFirstLoad
+          ? <SceletonGrid count={12} />
+          : (status === 'loading' && items.length > 0) ? <Loader /> : null}
         {status === 'failed' && <p>Error: {error || 'Failed to load categories'}</p>}
-        {categoriesToShow.length > 0 ? (categoriesToShow.map((category) => (
+        {!isFirstLoad && (categoriesToShow.length > 0 ? (categoriesToShow.map((category) => (
           <CategoriesItems key={category.id}
             id={category.id}
             image={category.image}
@@ -49,9 +54,7 @@ const CategoriesPage = () => {
           />
         ))) : (
           <p>No categories available</p>
-        )}
-
-
+        ))}
       </div>
     </div>
   );

--- a/frontend/src/features/discounts/pages/DiscountsPage.jsx
+++ b/frontend/src/features/discounts/pages/DiscountsPage.jsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import ProductCard from '@features/products/components/ProductCard.jsx';
 import { fetchProducts } from '@redux/slices/productSlice.js';
 import TitleList from '@common/components/ui/title/TitleList.jsx';
-
+import SceletonGrid from '@common/components/ui/sceleton/SceletonGrid.jsx';
 import prodStyles from '@features/products/pages/ProductsPage.module.css';
 import styles from './DiscountPage.module.css';
 
@@ -19,7 +19,7 @@ const DiscountsPage = () => {
     dispatch(fetchProducts());
   }, [dispatch]);
 
-  if (status === 'loading') return <p>Loading...</p>;
+  const isFirstLoad = (status === 'idle' || status === 'loading') && items.length === 0;
   if (status === 'failed') return <p>Error: {error}</p>;
 
   let discountedItems = items.filter(p => p.discont_price);
@@ -59,9 +59,10 @@ const DiscountsPage = () => {
         </div>
       </div>
       <div className={prodStyles.productGrid}>
-        {discountedItems.map(prod => (
-          <ProductCard key={prod.id} product={prod} />
-        ))}
+        {isFirstLoad
+          ? <SceletonGrid count={12} />
+          : discountedItems.map(prod => <ProductCard key={prod.id} product={prod} />)
+        }
       </div>
     </div>
   );

--- a/frontend/src/features/products/pages/ProductsPage.jsx
+++ b/frontend/src/features/products/pages/ProductsPage.jsx
@@ -4,6 +4,7 @@ import { useParams } from 'react-router-dom';
 import { fetchProducts } from '@redux/slices/productSlice.js';
 import ProductCard from '../components/ProductCard.jsx';
 import { Loader } from '@common/components';
+import SceletonGrid from '@common/components/ui/sceleton/SceletonGrid.jsx';
 import styles from './ProductsPage.module.css';
 import FilterSortControls from '../../filterSort/FilterSortControls.jsx'; // Новый компонент
 import TitleList from '@common/components/ui/title/TitleList.jsx';
@@ -13,15 +14,13 @@ const ProductsPage = () => {
   const { id } = useParams();
   const { items, status } = useSelector(state => state.products);
   const { items: categories } = useSelector(state => state.categories);
-
+  const isFirstLoad = status === 'loading' && items.length === 0;
   const [filters, setFilters] = useState({ minPrice: '', maxPrice: '', discounted: false });
   const [sort, setSort] = useState('default');
 
   useEffect(() => {
     dispatch(fetchProducts({ categoryId: id, ...filters, sort }));
   }, [dispatch, id, filters, sort]);
-
-  if (status === 'loading' && items.length === 0) return <Loader />;
 
   let filteredSortedItems = [...items];
 
@@ -57,9 +56,15 @@ const ProductsPage = () => {
         <FilterSortControls onChange={handlePriceChange} onDiscountedChange={handleDiscountedChange} onSortChange={setSort} /> {/* Обновлённый вызов с отдельными handlers, если нужно; или один onChange */}
       </div>
       <div className={styles.productGrid}>
-        {filteredSortedItems.slice(0, 35).map(prod => (
-          <ProductCard key={prod.id} product={prod} />
-        ))}
+        {isFirstLoad ? (
+          <SceletonGrid count={12} />
+        ) : status === 'loading' ? (
+          <Loader />
+        ) : (
+          filteredSortedItems.slice(0, 35).map(prod => (
+            <ProductCard key={prod.id} product={prod} />
+          ))
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
**Done**
- Added reusable skeleton: src/common/components/ui/sceleton/SkeletonGrid.jsx + .module.css.
- Integrated skeleton on first load ((status==='idle' || 'loading') && items.length===0):
- ProductsPage.jsx (All Products)
- CategoriesPage.jsx (Products by Category)
- DiscountsPage.jsx (Sale Products)
- FavoritesPage.jsx.

**Checks**
- Navigate to each page above → placeholders appear first, real cards replace them after data arrives.
- Layout matches parent grids (4-up where applicable).

**Notes**
- Import path unified: @common/components/ui/sceleton/SceletonGrid.jsx.